### PR TITLE
Fix license file attribute typo

### DIFF
--- a/AASAXUtilLib/LicenseGenerator.cs
+++ b/AASAXUtilLib/LicenseGenerator.cs
@@ -102,7 +102,7 @@ namespace AASAXUtilLib
             {
                 XElement xelement1 = new XElement((XName)"License");
                 xelement1.Add((object)new XAttribute((XName)"version", (object)this.version));
-                xelement1.Add((object)new XAttribute((XName)"certificateSerialNumer", (object)certificate.SerialNumber));
+                xelement1.Add((object)new XAttribute((XName)"certificateSerialNumber", (object)certificate.SerialNumber));
                 xelement1.Add((object)new XAttribute((XName)"licensecode", (object)this.licenseInfo.LicenseCode));
                 xelement1.Add((object)new XAttribute((XName)"serialnumber", (object)this.licenseInfo.SerialNumber));
                 if (this.licenseInfo.ExpirationDate.HasValue)
@@ -147,7 +147,7 @@ namespace AASAXUtilLib
 
                 XElement xelement1 = new XElement((XName)"License");
                 xelement1.Add((object)new XAttribute((XName)"version", (object)this.version));
-                xelement1.Add((object)new XAttribute((XName)"certificateSerialNumer", (object)serialNumber));
+                xelement1.Add((object)new XAttribute((XName)"certificateSerialNumber", (object)serialNumber));
                 xelement1.Add((object)new XAttribute((XName)"licensecode", (object)this.licenseInfo.LicenseCode));
                 xelement1.Add((object)new XAttribute((XName)"serialnumber", (object)this.licenseInfo.SerialNumber));
                 if (this.licenseInfo.ExpirationDate.HasValue)


### PR DESCRIPTION
## Summary
- fix `certificateSerialNumber` attribute typo in license generation

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff0c105f483289c5b8379bae34390