### PR TITLE
Validate certificate before signing

### DIFF
--- a/AASAXUtilLib/LicenseGenerator.cs
+++ b/AASAXUtilLib/LicenseGenerator.cs
@@ -79,8 +79,10 @@ namespace AASAXUtilLib
 
         internal bool GenerateLicense(X509Certificate2 usbCertificate)
         {
-            X509Certificate2 certificate = usbCertificate;
-            return certificate != null && this.GenerateLicenseFile(this.GenerateSignature(certificate), certificate);
+            if (usbCertificate == null || !ValidateCertificate(usbCertificate))
+                return false;
+
+            return GenerateLicenseFile(GenerateSignature(usbCertificate), usbCertificate);
         }
 
         internal bool GenerateLicenseKeyVault(string keyVaultDNS, string keyName, string tenantId, string clientId, string clientSecret)


### PR DESCRIPTION
## Summary
- ensure `GenerateLicense` validates the certificate before signing

## Testing
- `dotnet build ISVLicenseGenerator.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff2bd4cb08328bb89a50dddbb2f08