### PR TITLE
Fix Browse button path assignment

### DIFF
--- a/ISVLicenseGenerator/ISVLicenseGeneratorForm.cs
+++ b/ISVLicenseGenerator/ISVLicenseGeneratorForm.cs
@@ -64,13 +64,9 @@ namespace ISVLicenseGeneratorCore
             saveFileDialog.Title = "Save license";
             saveFileDialog.ShowDialog();
 
-            if (!String.IsNullOrEmpty(saveFileDialog.FileName))
+            if (!string.IsNullOrEmpty(saveFileDialog.FileName))
             {
-                System.IO.FileStream fs = (System.IO.FileStream)saveFileDialog.OpenFile();
-
                 PathTB.Text = saveFileDialog.FileName;
-
-                fs.Close();
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid unnecessary file creation when selecting a save path

## Testing
- `dotnet build ISVLicenseGenerator.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ff2aa7e348328876c17331115748f